### PR TITLE
Fix compatibility with typer 0.20.1+

### DIFF
--- a/src/sphinxcontrib/typer/__init__.py
+++ b/src/sphinxcontrib/typer/__init__.py
@@ -48,7 +48,7 @@ from sphinx.util import logging
 from sphinx.util.nodes import make_refnode
 
 from typer import rich_utils as typer_rich_utils
-from typer.core import TyperGroup
+from typer.core import MarkupMode, TyperGroup
 from typer.main import Typer
 from typer.main import get_command as get_typer_command
 from typer.models import Context as TyperContext
@@ -228,7 +228,7 @@ class TyperDirective(rst.Directive):
     theme: RenderTheme = RenderTheme.LIGHT
     preferred: t.Optional[RenderTarget] = None
 
-    markup_mode: t.Literal["markdown", "rich", None]
+    markup_mode: MarkupMode
 
     # the console_kwargs option can be a dict or a callable that returns a dict, the callable
     # must conform to the RenderOptions signature


### PR DESCRIPTION
## Summary

Fixes `AttributeError: module 'typer.rich_utils' has no attribute 'MarkupMode'` when using typer 0.20.1+.

## Problem

typer 0.20.1 removed `MarkupMode` from `typer.rich_utils`, causing sphinxcontrib-typer to fail at import time:

```
AttributeError: module 'typer.rich_utils' has no attribute 'MarkupMode'
```

## Solution

Import `MarkupMode` from `typer.core` instead of `typer.rich_utils`.

`MarkupMode` has been available in `typer.core` since at least version 0.9.0, well before the minimum supported version (0.12.0), so this change is backwards compatible with all supported typer versions.

## Changes

- Import `MarkupMode` from `typer.core`
- Update type annotation to use the new import
