### PR TITLE
Fix to support Typer 0.26.8

### DIFF
--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -4,6 +4,11 @@
 Change Log
 ==========
 
+v0.9.1 (2026-06-29)
+===================
+
+* Fixed `Does not work with latest release of Typer, 0.26.8 <https://github.com/sphinx-contrib/typer/issues/68>`_
+
 v0.9.0 (2026-06-01)
 ===================
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "sphinxcontrib-typer"
-version = "0.9.0"
+version = "0.9.1"
 requires-python = ">=3.10,<4.0"
 authors = [
   {name = "Brian Kohan", email = "bckohan@gmail.com"},
@@ -37,7 +37,7 @@ classifiers = [
 ]
 dependencies = [
     "sphinx>=6.0",
-    "typer>=0.26.0,<1.0.0"
+    "typer>=0.26.8,<1.0.0"
 ]
 
 

--- a/src/sphinxcontrib/typer/__init__.py
+++ b/src/sphinxcontrib/typer/__init__.py
@@ -57,7 +57,7 @@ from typer.main import get_command as get_typer_command
 from typer.models import Context as TyperContext
 from typer.models import TyperInfo
 
-VERSION = (0, 9, 0)
+VERSION = (0, 9, 1)
 
 __title__ = "SphinxContrib Typer"
 __version__ = ".".join(str(i) for i in VERSION)
@@ -483,8 +483,8 @@ class TyperDirective(rst.Directive):
                             "switch": typer_rich_utils.STYLE_SWITCH,
                             "negative_option": typer_rich_utils.STYLE_NEGATIVE_OPTION,
                             "negative_switch": typer_rich_utils.STYLE_NEGATIVE_SWITCH,
-                            "metavar": typer_rich_utils.STYLE_METAVAR,
-                            "metavar_sep": typer_rich_utils.STYLE_METAVAR_SEPARATOR,
+                            "types": typer_rich_utils.STYLE_TYPES,
+                            "types_sep": typer_rich_utils.STYLE_TYPES_SEPARATOR,
                             "usage": typer_rich_utils.STYLE_USAGE,
                         },
                     ),


### PR DESCRIPTION
Fix this package to support Typer 0.26.8 - uses new rich utils meta var naming introduced.

closes #68